### PR TITLE
Add extra search buttons and clean popup

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,37 +1,67 @@
+function createTab(id, labelText, onClick) {
+  const listContainer = document.querySelector('div[role="list"][style*="display:contents"]');
+  if (!listContainer || document.getElementById(id)) return;
+  const items = Array.from(listContainer.children);
+
+  const imagesItem = items.find(item => {
+    const a = item.querySelector('a');
+    return a && /Images/i.test(a.textContent);
+  });
+  if (!imagesItem) return;
+
+  const newItem = imagesItem.cloneNode(true);
+  newItem.id = id;
+
+  const a = newItem.querySelector('a');
+  a.removeAttribute('href');
+  a.addEventListener('click', e => {
+    e.preventDefault();
+    onClick();
+  });
+
+  const label = newItem.querySelector('div.YmvwI');
+  if (label) label.textContent = labelText;
+
+  listContainer.appendChild(newItem);
+}
+
 function insertMapsTab() {
   chrome.storage.local.get({ mapsEnabled: true }, data => {
     if (!data.mapsEnabled) return;
-    if (document.getElementById('maps-tab')) return;
-
-    const listContainer = document.querySelector('div[role="list"][style*="display:contents"]');
-    if (!listContainer) return;
-    const items = Array.from(listContainer.children);
-
-    const imagesItem = items.find(item => {
-      const a = item.querySelector('a');
-      return a && /Images|Images/i.test(a.textContent);
-    });
-    if (!imagesItem) return;
-
-    const mapsItem = imagesItem.cloneNode(true);
-    mapsItem.id = 'maps-tab';
-
-    const a = mapsItem.querySelector('a');
-    a.removeAttribute('href');
-    a.addEventListener('click', e => {
-      e.preventDefault();
+    createTab('maps-tab', 'Maps', () => {
       const query = document.querySelector('input[name="q"]').value || '';
       window.location.href = `https://www.google.com/maps/search/${encodeURIComponent(query)}`;
     });
-
-    const label = mapsItem.querySelector('div.YmvwI');
-    if (label) label.textContent = 'Maps';
-
-    listContainer.insertBefore(mapsItem, imagesItem);
   });
 }
 
-const observer = new MutationObserver(insertMapsTab);
+function insertOrthoTab() {
+  chrome.storage.local.get({ orthoEnabled: true }, data => {
+    if (!data.orthoEnabled) return;
+    createTab('ortho-tab', 'Orthographe', () => {
+      const query = document.querySelector('input[name="q"]').value || '';
+      window.location.href = `https://www.reverso.net/orthographe/correcteur-francais/#text=${encodeURIComponent(query)}`;
+    });
+  });
+}
+
+function insertTrendsTab() {
+  chrome.storage.local.get({ trendsEnabled: true }, data => {
+    if (!data.trendsEnabled) return;
+    createTab('trends-tab', 'Tendances', () => {
+      const query = document.querySelector('input[name="q"]').value || '';
+      window.location.href = `https://trends.google.fr/trends/explore?geo=FR&q=${encodeURIComponent(query)}`;
+    });
+  });
+}
+
+function insertAllTabs() {
+  insertMapsTab();
+  insertOrthoTab();
+  insertTrendsTab();
+}
+
+const observer = new MutationObserver(insertAllTabs);
 observer.observe(document.body, { childList: true, subtree: true });
 
-insertMapsTab();
+insertAllTabs();

--- a/popup.css
+++ b/popup.css
@@ -37,15 +37,6 @@ h1 {
   color: var(--accent);
 }
 
-#searchParam {
-  display: block;
-  width: calc(100% - 24px);
-  margin: 0 auto 12px auto;
-  padding: 8px 12px;
-  border: 1px solid #CCC;
-  border-radius: 6px;
-}
-
 .separator {
   border: none;
   height: 1px;

--- a/popup.html
+++ b/popup.html
@@ -12,8 +12,6 @@
       <h1>Google Search+</h1>
     </div>
 
-    <input type="text" id="searchParam" placeholder="🔍 Rechercher un réglage…">
-
     <hr class="separator">
 
     <div id="optionsList">
@@ -48,3 +46,8 @@
     <img src="icons/tendances.png" class="option-icon" alt="">
     <label><input type="checkbox" id="toggleTrends"> Tendances</label>
     </div>
+
+    </div> <!-- end optionsList -->
+  </div> <!-- end container -->
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -27,21 +27,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  const searchParam = document.getElementById('searchParam');
-  const optionEls = Array.from(document.querySelectorAll('.option'));
-  const groupEls  = Array.from(document.querySelectorAll('.category-group'));
-  searchParam.addEventListener('input', () => {
-    const q = searchParam.value.trim().toLowerCase();
-    // options individuelles
-    optionEls.forEach(opt => {
-      const txt = opt.dataset.search;
-      opt.style.display = txt.includes(q) ? 'flex' : 'none';
-    });
-    groupEls.forEach(gr => {
-      const txtGroup = gr.dataset.search;
-      const subs = Array.from(gr.querySelectorAll('.option'));
-      const anySub = subs.some(opt => opt.dataset.search.includes(q));
-      gr.style.display = (txtGroup.includes(q) || anySub) ? 'flex' : 'none';
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- inject Orthographe and Tendances tabs in Google results
- move Maps tab to be appended at the end and share tab creation logic
- remove useless search box from popup UI and related CSS/JS
- close popup.html structure

## Testing
- `node --check contentScript.js`
- `node --check popup.js`

------
https://chatgpt.com/codex/tasks/task_e_68765eb92710832aa45bd1c22752e0cd