### PR TITLE
Restore popup and fix chatgpt automation

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,36 @@
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (msg.action === 'openChatGPT') {
+    const query = msg.query || '';
+    chrome.tabs.create({ url: 'https://chat.openai.com/' }, tab => {
+      if (!tab || !tab.id) return;
+      const tabId = tab.id;
+      function injectScript() {
+        chrome.scripting.executeScript({
+          target: { tabId },
+          func: (q) => {
+            const fill = () => {
+              const area = document.querySelector('#prompt-textarea');
+              const sendBtn = document.querySelector('#composer-submit-button');
+              if (area && sendBtn) {
+                area.textContent = q;
+                area.dispatchEvent(new InputEvent('input', { bubbles: true }));
+                sendBtn.click();
+              } else {
+                setTimeout(fill, 500);
+              }
+            };
+            fill();
+          },
+          args: [query]
+        });
+      }
+      chrome.tabs.onUpdated.addListener(function listener(id, info, tabInfo) {
+        if (id === tabId && info.status === 'complete' &&
+            tabInfo.url && /chatgpt\.com|chat\.openai\.com/.test(tabInfo.url)) {
+          chrome.tabs.onUpdated.removeListener(listener);
+          injectScript();
+        }
+      });
+    });
+  }
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,37 +1,137 @@
+const defaultSettings = {
+  mapsEnabled: true,
+  sponsorsEnabled: true,
+  chatGptEnabled: true,
+  operatorsEnabled: true,
+  orthoEnabled: true,
+  trendsEnabled: true
+};
+let settings = { ...defaultSettings };
+
+chrome.storage.local.get(defaultSettings, data => {
+  settings = data;
+  insertAllTabs();
+});
+
+chrome.storage.onChanged.addListener(changes => {
+  for (const [key, { newValue }] of Object.entries(changes)) {
+    if (key in settings) settings[key] = newValue;
+  }
+  insertAllTabs();
+});
+
+function createTab(id, labelText, onClick, insertBeforeImages = false) {
+  const listContainer = document.querySelector('div[role="list"][style*="display:contents"]');
+  if (!listContainer || document.getElementById(id)) return;
+  const items = Array.from(listContainer.children);
+
+  const imagesItem = items.find(item => {
+    const a = item.querySelector('a');
+    return a && /Images/i.test(a.textContent);
+  });
+  if (!imagesItem) return;
+
+  const newItem = imagesItem.cloneNode(true);
+  newItem.id = id;
+
+  const a = newItem.querySelector('a');
+  a.removeAttribute('href');
+  a.addEventListener('click', e => {
+    e.preventDefault();
+    onClick();
+  });
+
+  const label = newItem.querySelector('div.YmvwI');
+  if (label) label.textContent = labelText;
+
+  if (insertBeforeImages) {
+    listContainer.insertBefore(newItem, imagesItem);
+  } else {
+    listContainer.appendChild(newItem);
+  }
+}
+
+function getQuery() {
+  const homeInput = document.querySelector('input#input.truncate');
+  if (homeInput) return homeInput.value || '';
+  const searchInput = document.querySelector('textarea#gLFyf, textarea#APjFqb, input[name="q"]');
+  return searchInput ? searchInput.value || '' : '';
+}
+
 function insertMapsTab() {
-  chrome.storage.local.get({ mapsEnabled: true }, data => {
-    if (!data.mapsEnabled) return;
-    if (document.getElementById('maps-tab')) return;
+  const existing = document.getElementById('maps-tab');
+  if (!settings.mapsEnabled) {
+    if (existing) existing.remove();
+    return;
+  }
+  if (existing) return;
+  createTab('maps-tab', 'Maps', () => {
+    const query = getQuery();
+    window.location.href = `https://www.google.com/maps/search/${encodeURIComponent(query)}`;
+  }, true);
+}
 
-    const listContainer = document.querySelector('div[role="list"][style*="display:contents"]');
-    if (!listContainer) return;
-    const items = Array.from(listContainer.children);
-
-    const imagesItem = items.find(item => {
-      const a = item.querySelector('a');
-      return a && /Images|Images/i.test(a.textContent);
-    });
-    if (!imagesItem) return;
-
-    const mapsItem = imagesItem.cloneNode(true);
-    mapsItem.id = 'maps-tab';
-
-    const a = mapsItem.querySelector('a');
-    a.removeAttribute('href');
-    a.addEventListener('click', e => {
-      e.preventDefault();
-      const query = document.querySelector('input[name="q"]').value || '';
-      window.location.href = `https://www.google.com/maps/search/${encodeURIComponent(query)}`;
-    });
-
-    const label = mapsItem.querySelector('div.YmvwI');
-    if (label) label.textContent = 'Maps';
-
-    listContainer.insertBefore(mapsItem, imagesItem);
+function insertOrthoTab() {
+  const existing = document.getElementById('ortho-tab');
+  if (!settings.orthoEnabled) {
+    if (existing) existing.remove();
+    return;
+  }
+  if (existing) return;
+  createTab('ortho-tab', 'Orthographe', () => {
+    const query = getQuery();
+    window.location.href = `https://www.reverso.net/orthographe/correcteur-francais/#text=${encodeURIComponent(query)}`;
   });
 }
 
-const observer = new MutationObserver(insertMapsTab);
+function insertTrendsTab() {
+  const existing = document.getElementById('trends-tab');
+  if (!settings.trendsEnabled) {
+    if (existing) existing.remove();
+    return;
+  }
+  if (existing) return;
+  createTab('trends-tab', 'Tendances', () => {
+    const query = getQuery();
+    window.location.href = `https://trends.google.fr/trends/explore?geo=FR&q=${encodeURIComponent(query)}`;
+  });
+}
+
+function insertChatgptButton() {
+  const existing = document.getElementById('chatgptButton');
+  if (!settings.chatGptEnabled) {
+    if (existing) existing.remove();
+    return;
+  }
+  const voiceBtn = document.querySelector('#voiceSearchButton, div[aria-label="Utiliser la recherche vocale"]');
+  if (!voiceBtn || existing) return;
+
+  const chatBtn = voiceBtn.cloneNode(true);
+  chatBtn.id = 'chatgptButton';
+  chatBtn.title = 'Envoyer à ChatGPT';
+  chatBtn.innerHTML = '';
+  const img = document.createElement('img');
+  img.src = chrome.runtime.getURL('icons/chatgpt.png');
+  img.style.width = '24px';
+  img.style.height = '24px';
+  chatBtn.appendChild(img);
+  chatBtn.addEventListener('click', e => {
+    e.preventDefault();
+    const query = getQuery();
+    chrome.runtime.sendMessage({ action: 'openChatGPT', query });
+  });
+
+  voiceBtn.parentNode.insertBefore(chatBtn, voiceBtn);
+}
+
+function insertAllTabs() {
+  insertMapsTab();
+  insertOrthoTab();
+  insertTrendsTab();
+  insertChatgptButton();
+}
+
+const observer = new MutationObserver(insertAllTabs);
 observer.observe(document.body, { childList: true, subtree: true });
 
-insertMapsTab();
+insertAllTabs();

--- a/manifest.json
+++ b/manifest.json
@@ -5,10 +5,13 @@
   "version": "1.0.0",
   "permissions": [
     "storage",
-    "scripting"
+    "scripting",
+    "tabs"
   ],
   "host_permissions": [
-    "*://*.google.com/*"
+    "*://*.google.com/*",
+    "*://chat.openai.com/*",
+    "*://chatgpt.com/*"
   ],
   "action": {
     "default_popup": "popup.html",
@@ -29,5 +32,8 @@
       "js": ["contentScript.js"],
       "css": ["contentScript.css"]
     }
-  ]
+  ],
+  "background": {
+    "service_worker": "background.js"
+  }
 }

--- a/popup.css
+++ b/popup.css
@@ -37,15 +37,6 @@ h1 {
   color: var(--accent);
 }
 
-#searchParam {
-  display: block;
-  width: calc(100% - 24px);
-  margin: 0 auto 12px auto;
-  padding: 8px 12px;
-  border: 1px solid #CCC;
-  border-radius: 6px;
-}
-
 .separator {
   border: none;
   height: 1px;

--- a/popup.html
+++ b/popup.html
@@ -12,39 +12,21 @@
       <h1>Google Search+</h1>
     </div>
 
-    <input type="text" id="searchParam" placeholder="🔍 Rechercher un réglage…">
-
     <hr class="separator">
 
     <div id="optionsList">
+      <div class="option"><img src="icons/maps.png" class="option-icon" alt=""><label><input type="checkbox" id="toggleMaps"> Réactiver Maps</label></div>
+      <div class="option"><img src="icons/sponsor.png" class="option-icon" alt=""><label><input type="checkbox" id="toggleSponsors"> Bloquer les résultats sponsorisés</label></div>
+      <div class="option"><img src="icons/chatgpt.png" class="option-icon" alt=""><label><input type="checkbox" id="toggleChatGPT"> Bouton ChatGPT</label></div>
+      <div class="option"><img src="icons/operators.png" class="option-icon" alt=""><label><input type="checkbox" id="toggleOperators"> Opérateurs avancés</label></div>
 
-      <!-- OPTIONS GÉNÉRALES -->
-      <div class="option" data-search="maps">
-        <img src="icons/maps.png" class="option-icon" alt="">
-        <label><input type="checkbox" id="toggleMaps"> Réactiver Maps</label>
-      </div>
-      <div class="option" data-search="sponsor sponsorisé bloquer résultats">
-        <img src="icons/sponsor.png" class="option-icon" alt="">
-        <label><input type="checkbox" id="toggleSponsors"> Bloquer les résultats sponsorisés</label>
-      </div>
-      <div class="option" data-search="chatgpt chat gpt conversation">
-        <img src="icons/chatgpt.png" class="option-icon" alt="">
-        <label><input type="checkbox" id="toggleChatGPT"> Bouton ChatGPT</label>
-      </div>
-      <div class="option" data-search="opérateur opérateurs avancés recherche">
-        <img src="icons/operators.png" class="option-icon" alt="">
-        <label><input type="checkbox" id="toggleOperators"> Opérateurs avancés</label>
-      </div>
-
-    <hr class="separator-small">
-
-    <!-- OPTIONS PERSONNALISEES -->
-    <h2 class="subheader">Catégories personnalisées</h2>
-    <div class="option" data-search="orthographe">
-    <img src="icons/orthographe.png" class="option-icon" alt="">
-    <label><input type="checkbox" id="toggleOrtho"> Orthographe</label>
+      <hr class="separator-small">
+      <h2 class="subheader">Catégories personnalisées</h2>
+      <div class="option"><img src="icons/orthographe.png" class="option-icon" alt=""><label><input type="checkbox" id="toggleOrtho"> Orthographe</label></div>
+      <div class="option"><img src="icons/tendances.png" class="option-icon" alt=""><label><input type="checkbox" id="toggleTrends"> Tendances</label></div>
     </div>
-    <div class="option" data-search="tendances">
-    <img src="icons/tendances.png" class="option-icon" alt="">
-    <label><input type="checkbox" id="toggleTrends"> Tendances</label>
-    </div>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,17 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
   const settings = [
-    { id: 'toggleMaps',       key: 'mapsEnabled' },
-    { id: 'toggleSponsors',   key: 'sponsorsEnabled' },
-    { id: 'toggleChatGPT',    key: 'chatGptEnabled' },
-    { id: 'toggleOperators',  key: 'operatorsEnabled' },
-    { id: 'toggleCustomCats', key: 'customCatsEnabled' },
-    { id: 'toggleOrtho',      key: 'orthoEnabled' },
-    { id: 'toggleTrends',     key: 'trendsEnabled' }
+    { id: 'toggleMaps',      key: 'mapsEnabled' },
+    { id: 'toggleSponsors',  key: 'sponsorsEnabled' },
+    { id: 'toggleChatGPT',   key: 'chatGptEnabled' },
+    { id: 'toggleOperators', key: 'operatorsEnabled' },
+    { id: 'toggleOrtho',     key: 'orthoEnabled' },
+    { id: 'toggleTrends',    key: 'trendsEnabled' }
   ];
 
-  const ids = settings.map(s => s.id);
   const defaults = {};
   settings.forEach(s => defaults[s.key] = true);
+
   chrome.storage.local.get(defaults, data => {
     settings.forEach(s => {
       const cb = document.getElementById(s.id);
@@ -24,24 +23,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!cb) return;
     cb.addEventListener('change', () => {
       chrome.storage.local.set({ [s.key]: cb.checked });
-    });
-  });
-
-  const searchParam = document.getElementById('searchParam');
-  const optionEls = Array.from(document.querySelectorAll('.option'));
-  const groupEls  = Array.from(document.querySelectorAll('.category-group'));
-  searchParam.addEventListener('input', () => {
-    const q = searchParam.value.trim().toLowerCase();
-    // options individuelles
-    optionEls.forEach(opt => {
-      const txt = opt.dataset.search;
-      opt.style.display = txt.includes(q) ? 'flex' : 'none';
-    });
-    groupEls.forEach(gr => {
-      const txtGroup = gr.dataset.search;
-      const subs = Array.from(gr.querySelectorAll('.option'));
-      const anySub = subs.some(opt => opt.dataset.search.includes(q));
-      gr.style.display = (txtGroup.includes(q) || anySub) ? 'flex' : 'none';
     });
   });
 });


### PR DESCRIPTION
## Summary
- show feature toggles again in `popup.html`
- restore popup logic for saving options
- respect saved options when inserting tabs/buttons
- allow scripting on chatgpt.com and wait for final URL before sending the query

## Testing
- `node --check contentScript.js`
- `node --check background.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68765eb92710832aa45bd1c22752e0cd